### PR TITLE
feat: add responsive ToolbarMenu and window size hook

### DIFF
--- a/src/components/features/ToolbarMenu/index.tsx
+++ b/src/components/features/ToolbarMenu/index.tsx
@@ -1,0 +1,27 @@
+import { Popover } from "@/components/ui/popover";
+import { IReactChildren } from "@/types/core";
+import { ReactElement } from "react";
+
+import { Container } from "./styles";
+
+interface IToolbarMenuProps extends IReactChildren {
+    open?: boolean;
+}
+
+const ToolbarMenu = ({ open, children }: IToolbarMenuProps): ReactElement => {
+    return <Popover open={open}>{children}</Popover>;
+};
+
+const Trigger = ({ children }: IReactChildren): ReactElement => (
+    <Popover.Trigger>{children}</Popover.Trigger>
+);
+ToolbarMenu.Trigger = Trigger;
+
+const Content = ({ children }: IReactChildren): ReactElement => (
+    <Popover.Content align="end" sideOffset={4} hasCloseButton={false} hasArrow={false}>
+        <Container>{children}</Container>
+    </Popover.Content>
+);
+ToolbarMenu.Content = Content;
+
+export { ToolbarMenu };

--- a/src/components/features/ToolbarMenu/styles.ts
+++ b/src/components/features/ToolbarMenu/styles.ts
@@ -1,0 +1,14 @@
+import styled from "@emotion/styled";
+
+export const Container = styled.div`
+    display: flex;
+    flex-direction: row;
+    background: ${({ theme }) => theme.colors.white};
+    border: 1px solid ${({ theme }) => theme.colors.gray40};
+    border-radius: 6px;
+    box-shadow:
+        0 10px 15px -3px rgba(0, 0, 0, 0.01),
+        0 4px 6px -2px rgba(0, 0, 0, 0.05);
+    overflow: hidden;
+    padding: 5px;
+`;

--- a/src/components/features/toolbar/styles.ts
+++ b/src/components/features/toolbar/styles.ts
@@ -26,7 +26,7 @@ export const StyledGroup = styled.div<IStyledGroupProps>`
     }
 `;
 
-export const StyledItem = styled.div`
+export const StyledItem = styled.button`
     display: flex;
     align-items: center;
     justify-content: center;

--- a/src/components/layouts/document/documentToolbar/index.tsx
+++ b/src/components/layouts/document/documentToolbar/index.tsx
@@ -84,7 +84,7 @@ export const DocumentToolbar = ({
     highlightColor,
     onChangeHighlightColor,
 }: IDocumentToolbarProps): ReactElement => {
-    const { width: windowsWidth } = useWindowSize();
+    const { width: windowWidth } = useWindowSize();
 
     const [moreOptionsIsActive, setMoreOptionsIsActive] = useState<boolean>(false);
 
@@ -178,7 +178,7 @@ export const DocumentToolbar = ({
                     </ColorPicker>
                 </Toolbar.Group>
 
-                {windowsWidth > 1080 && (
+                {windowWidth > 1080 && (
                     <Toolbar.Group className="TextFormat Item">
                         <Toolbar.ItemButton active={isBoldActive} onClick={onBoldClick}>
                             <MdFormatBold size={18} color="black" />
@@ -201,7 +201,7 @@ export const DocumentToolbar = ({
                     </Toolbar.Group>
                 )}
 
-                {windowsWidth > 1240 && (
+                {windowWidth > 1240 && (
                     <Toolbar.Group className="TextAlignment Item">
                         <Toolbar.ItemButton active={isLeftAlignActive} onClick={onLeftAlignClick}>
                             <MdFormatAlignLeft size={18} color="black" />
@@ -224,7 +224,7 @@ export const DocumentToolbar = ({
                     </Toolbar.Group>
                 )}
 
-                {windowsWidth > 1400 && (
+                {windowWidth > 1400 && (
                     <Toolbar.Group className="ListFormat Item">
                         <Toolbar.ItemButton>
                             <MdFormatLineSpacing size={18} color="black" />
@@ -256,7 +256,7 @@ export const DocumentToolbar = ({
                         </ToolbarMenu.Trigger>
 
                         <ToolbarMenu.Content>
-                            {windowsWidth < 1400 && (
+                            {windowWidth < 1400 && (
                                 <Toolbar.Group className="ListFormat Item">
                                     <Toolbar.ItemButton>
                                         <MdFormatLineSpacing size={18} color="black" />
@@ -282,7 +282,7 @@ export const DocumentToolbar = ({
                                 </Toolbar.Group>
                             )}
 
-                            {windowsWidth < 1240 && (
+                            {windowWidth < 1240 && (
                                 <Toolbar.Group className="TextAlignment Item">
                                     <Toolbar.ItemButton
                                         active={isLeftAlignActive}
@@ -317,7 +317,7 @@ export const DocumentToolbar = ({
                                 </Toolbar.Group>
                             )}
 
-                            {windowsWidth < 1080 && (
+                            {windowWidth < 1080 && (
                                 <Toolbar.Group className="TextFormat Item">
                                     <Toolbar.ItemButton active={isBoldActive} onClick={onBoldClick}>
                                         <MdFormatBold size={18} color="black" />

--- a/src/components/layouts/document/documentToolbar/index.tsx
+++ b/src/components/layouts/document/documentToolbar/index.tsx
@@ -2,8 +2,10 @@ import { IconFormatInkHighlighter } from "@/assets/svgs/icons";
 import { ColorPicker } from "@/components/features/colorPicker";
 import { Selector } from "@/components/features/selector";
 import { Toolbar } from "@/components/features/toolbar";
+import { ToolbarMenu } from "@/components/features/ToolbarMenu";
+import { useWindowSize } from "@/hooks/useWindowSize";
 import { Theme } from "@/themes";
-import { ChangeEvent, ReactElement } from "react";
+import { ChangeEvent, ReactElement, useState } from "react";
 import { BiMinus } from "react-icons/bi";
 import {
     MdAdd,
@@ -82,6 +84,10 @@ export const DocumentToolbar = ({
     highlightColor,
     onChangeHighlightColor,
 }: IDocumentToolbarProps): ReactElement => {
+    const { width: windowsWidth } = useWindowSize();
+
+    const [moreOptionsIsActive, setMoreOptionsIsActive] = useState<boolean>(false);
+
     const changeFontSize = (newSize: number) => {
         if (newSize < 1 || newSize > 200) return;
         onChangeFontSize(newSize);
@@ -172,61 +178,178 @@ export const DocumentToolbar = ({
                     </ColorPicker>
                 </Toolbar.Group>
 
-                <Toolbar.Group className="TextFormat Item">
-                    <Toolbar.ItemButton active={isBoldActive} onClick={onBoldClick}>
-                        <MdFormatBold size={18} color="black" />
-                    </Toolbar.ItemButton>
+                {windowsWidth > 1080 && (
+                    <Toolbar.Group className="TextFormat Item">
+                        <Toolbar.ItemButton active={isBoldActive} onClick={onBoldClick}>
+                            <MdFormatBold size={18} color="black" />
+                        </Toolbar.ItemButton>
 
-                    <Toolbar.ItemButton active={isItalicActive} onClick={onItalicClick}>
-                        <MdFormatItalic size={18} color={Theme.colors.black} />
-                    </Toolbar.ItemButton>
+                        <Toolbar.ItemButton active={isItalicActive} onClick={onItalicClick}>
+                            <MdFormatItalic size={18} color={Theme.colors.black} />
+                        </Toolbar.ItemButton>
 
-                    <Toolbar.ItemButton active={isUnderlineActive} onClick={onUnderlineClick}>
-                        <MdFormatUnderlined size={18} color={Theme.colors.black} />
-                    </Toolbar.ItemButton>
+                        <Toolbar.ItemButton active={isUnderlineActive} onClick={onUnderlineClick}>
+                            <MdFormatUnderlined size={18} color={Theme.colors.black} />
+                        </Toolbar.ItemButton>
 
-                    <Toolbar.ItemButton
-                        active={isStrikethroughActive}
-                        onClick={onStrikethroughClick}
-                    >
-                        <MdFormatStrikethrough size={18} color={Theme.colors.black} />
-                    </Toolbar.ItemButton>
-                </Toolbar.Group>
+                        <Toolbar.ItemButton
+                            active={isStrikethroughActive}
+                            onClick={onStrikethroughClick}
+                        >
+                            <MdFormatStrikethrough size={18} color={Theme.colors.black} />
+                        </Toolbar.ItemButton>
+                    </Toolbar.Group>
+                )}
 
-                <Toolbar.Group className="TextAlignment Item">
-                    <Toolbar.ItemButton active={isLeftAlignActive} onClick={onLeftAlignClick}>
-                        <MdFormatAlignLeft size={18} color="black" />
-                    </Toolbar.ItemButton>
-                    <Toolbar.ItemButton active={isCenterAlignActive} onClick={onCenterAlignClick}>
-                        <MdOutlineFormatAlignCenter size={18} color={Theme.colors.black} />
-                    </Toolbar.ItemButton>
-                    <Toolbar.ItemButton active={isRightAlignActive} onClick={onRightAlignClick}>
-                        <MdFormatAlignRight size={18} color={Theme.colors.black} />
-                    </Toolbar.ItemButton>
-                    <Toolbar.ItemButton active={isJustifyAlignActive} onClick={onJustifyAlignClick}>
-                        <MdFormatAlignJustify size={18} color={Theme.colors.black} />
-                    </Toolbar.ItemButton>
-                </Toolbar.Group>
+                {windowsWidth > 1240 && (
+                    <Toolbar.Group className="TextAlignment Item">
+                        <Toolbar.ItemButton active={isLeftAlignActive} onClick={onLeftAlignClick}>
+                            <MdFormatAlignLeft size={18} color="black" />
+                        </Toolbar.ItemButton>
+                        <Toolbar.ItemButton
+                            active={isCenterAlignActive}
+                            onClick={onCenterAlignClick}
+                        >
+                            <MdOutlineFormatAlignCenter size={18} color={Theme.colors.black} />
+                        </Toolbar.ItemButton>
+                        <Toolbar.ItemButton active={isRightAlignActive} onClick={onRightAlignClick}>
+                            <MdFormatAlignRight size={18} color={Theme.colors.black} />
+                        </Toolbar.ItemButton>
+                        <Toolbar.ItemButton
+                            active={isJustifyAlignActive}
+                            onClick={onJustifyAlignClick}
+                        >
+                            <MdFormatAlignJustify size={18} color={Theme.colors.black} />
+                        </Toolbar.ItemButton>
+                    </Toolbar.Group>
+                )}
 
-                <Toolbar.Group className="ListFormat Item">
-                    <Toolbar.ItemButton>
-                        <MdFormatLineSpacing size={18} color="black" />
-                    </Toolbar.ItemButton>
-                    <Toolbar.ItemButton>
-                        <MdFormatListBulleted size={18} color={Theme.colors.black} />
-                    </Toolbar.ItemButton>
-                    <Toolbar.ItemButton>
-                        <MdFormatListNumbered size={18} color={Theme.colors.black} />
-                    </Toolbar.ItemButton>
-                    <Toolbar.ItemButton>
-                        <MdFormatClear size={18} color={Theme.colors.black} />
-                    </Toolbar.ItemButton>
-                </Toolbar.Group>
+                {windowsWidth > 1400 && (
+                    <Toolbar.Group className="ListFormat Item">
+                        <Toolbar.ItemButton>
+                            <MdFormatLineSpacing size={18} color="black" />
+                        </Toolbar.ItemButton>
+
+                        <Toolbar.ItemButton>
+                            <MdFormatListBulleted size={18} color={Theme.colors.black} />
+                        </Toolbar.ItemButton>
+
+                        <Toolbar.ItemButton>
+                            <MdFormatListNumbered size={18} color={Theme.colors.black} />
+                        </Toolbar.ItemButton>
+
+                        <Toolbar.ItemButton>
+                            <MdFormatClear size={18} color={Theme.colors.black} />
+                        </Toolbar.ItemButton>
+                    </Toolbar.Group>
+                )}
 
                 <Toolbar.Group className="MoreOptions Item">
-                    <Toolbar.ItemButton>
-                        <MdMoreHoriz size={18} color="black" />
-                    </Toolbar.ItemButton>
+                    <ToolbarMenu open={moreOptionsIsActive}>
+                        <ToolbarMenu.Trigger>
+                            <Toolbar.ItemButton
+                                active={moreOptionsIsActive}
+                                onClick={() => setMoreOptionsIsActive(!moreOptionsIsActive)}
+                            >
+                                <MdMoreHoriz size={18} color="black" />
+                            </Toolbar.ItemButton>
+                        </ToolbarMenu.Trigger>
+
+                        <ToolbarMenu.Content>
+                            {windowsWidth < 1400 && (
+                                <Toolbar.Group className="ListFormat Item">
+                                    <Toolbar.ItemButton>
+                                        <MdFormatLineSpacing size={18} color="black" />
+                                    </Toolbar.ItemButton>
+
+                                    <Toolbar.ItemButton>
+                                        <MdFormatListBulleted
+                                            size={18}
+                                            color={Theme.colors.black}
+                                        />
+                                    </Toolbar.ItemButton>
+
+                                    <Toolbar.ItemButton>
+                                        <MdFormatListNumbered
+                                            size={18}
+                                            color={Theme.colors.black}
+                                        />
+                                    </Toolbar.ItemButton>
+
+                                    <Toolbar.ItemButton>
+                                        <MdFormatClear size={18} color={Theme.colors.black} />
+                                    </Toolbar.ItemButton>
+                                </Toolbar.Group>
+                            )}
+
+                            {windowsWidth < 1240 && (
+                                <Toolbar.Group className="TextAlignment Item">
+                                    <Toolbar.ItemButton
+                                        active={isLeftAlignActive}
+                                        onClick={onLeftAlignClick}
+                                    >
+                                        <MdFormatAlignLeft size={18} color="black" />
+                                    </Toolbar.ItemButton>
+                                    <Toolbar.ItemButton
+                                        active={isCenterAlignActive}
+                                        onClick={onCenterAlignClick}
+                                    >
+                                        <MdOutlineFormatAlignCenter
+                                            size={18}
+                                            color={Theme.colors.black}
+                                        />
+                                    </Toolbar.ItemButton>
+                                    <Toolbar.ItemButton
+                                        active={isRightAlignActive}
+                                        onClick={onRightAlignClick}
+                                    >
+                                        <MdFormatAlignRight size={18} color={Theme.colors.black} />
+                                    </Toolbar.ItemButton>
+                                    <Toolbar.ItemButton
+                                        active={isJustifyAlignActive}
+                                        onClick={onJustifyAlignClick}
+                                    >
+                                        <MdFormatAlignJustify
+                                            size={18}
+                                            color={Theme.colors.black}
+                                        />
+                                    </Toolbar.ItemButton>
+                                </Toolbar.Group>
+                            )}
+
+                            {windowsWidth < 1080 && (
+                                <Toolbar.Group className="TextFormat Item">
+                                    <Toolbar.ItemButton active={isBoldActive} onClick={onBoldClick}>
+                                        <MdFormatBold size={18} color="black" />
+                                    </Toolbar.ItemButton>
+
+                                    <Toolbar.ItemButton
+                                        active={isItalicActive}
+                                        onClick={onItalicClick}
+                                    >
+                                        <MdFormatItalic size={18} color={Theme.colors.black} />
+                                    </Toolbar.ItemButton>
+
+                                    <Toolbar.ItemButton
+                                        active={isUnderlineActive}
+                                        onClick={onUnderlineClick}
+                                    >
+                                        <MdFormatUnderlined size={18} color={Theme.colors.black} />
+                                    </Toolbar.ItemButton>
+
+                                    <Toolbar.ItemButton
+                                        active={isStrikethroughActive}
+                                        onClick={onStrikethroughClick}
+                                    >
+                                        <MdFormatStrikethrough
+                                            size={18}
+                                            color={Theme.colors.black}
+                                        />
+                                    </Toolbar.ItemButton>
+                                </Toolbar.Group>
+                            )}
+                        </ToolbarMenu.Content>
+                    </ToolbarMenu>
                 </Toolbar.Group>
             </Toolbar>
         </Root>

--- a/src/components/layouts/document/documentToolbar/styles.ts
+++ b/src/components/layouts/document/documentToolbar/styles.ts
@@ -4,35 +4,11 @@ export const Root = styled.div<{ zoom: number }>`
     display: flex;
     width: 100%;
     height: 100%;
-    max-width: ${({ zoom }) => `${810 * (zoom / 100)}px`};
+    /* max-width: ${({ zoom }) => `${810 * (zoom / 100)}px`}; */
 
     > section {
-        grid-template-columns: minmax(100px, 1fr) auto 86px 156px 156px 156px 50px;
+        grid-template-columns: minmax(100px, 1fr) auto auto auto auto auto auto;
         grid-template-rows: 1fr;
-
-        @media (max-width: 1304px) {
-            grid-template-columns: minmax(100px, 1fr) auto 86px 156px 156px 50px;
-
-            .ListFormat {
-                display: none;
-            }
-        }
-
-        @media (max-width: 1147px) {
-            grid-template-columns: minmax(100px, 1fr) auto 86px 156px 50px;
-
-            .TextAlignment {
-                display: none;
-            }
-        }
-
-        @media (max-width: 994px) {
-            grid-template-columns: minmax(100px, 1fr) auto 86px 50px;
-
-            .TextFormat {
-                display: none;
-            }
-        }
     }
 `;
 

--- a/src/hooks/useWindowSize.ts
+++ b/src/hooks/useWindowSize.ts
@@ -1,0 +1,28 @@
+import { useState, useEffect } from "react";
+
+interface IWindowsSize {
+    width: number;
+    height: number;
+}
+
+const useWindowSize = (): IWindowsSize => {
+    const [windowsSize, setWindowsSize] = useState<IWindowsSize>({ width: 0, height: 0 });
+
+    useEffect(() => {
+        const handleResize = (): void => {
+            setWindowsSize({
+                width: window.innerWidth,
+                height: window.innerHeight,
+            });
+        };
+
+        window.addEventListener("resize", handleResize);
+        handleResize();
+
+        return () => window.removeEventListener("resize", handleResize);
+    }, []);
+
+    return windowsSize;
+};
+
+export { useWindowSize };

--- a/src/hooks/useWindowSize.ts
+++ b/src/hooks/useWindowSize.ts
@@ -1,16 +1,16 @@
 import { useState, useEffect } from "react";
 
-interface IWindowsSize {
+interface IWindowSize {
     width: number;
     height: number;
 }
 
-const useWindowSize = (): IWindowsSize => {
-    const [windowsSize, setWindowsSize] = useState<IWindowsSize>({ width: 0, height: 0 });
+const useWindowSize = (): IWindowSize => {
+    const [windowSize, setWindowSize] = useState<IWindowSize>({ width: 0, height: 0 });
 
     useEffect(() => {
         const handleResize = (): void => {
-            setWindowsSize({
+            setWindowSize({
                 width: window.innerWidth,
                 height: window.innerHeight,
             });
@@ -22,7 +22,7 @@ const useWindowSize = (): IWindowsSize => {
         return () => window.removeEventListener("resize", handleResize);
     }, []);
 
-    return windowsSize;
+    return windowSize;
 };
 
 export { useWindowSize };


### PR DESCRIPTION
This pull request introduces a responsive design for the document toolbar by dynamically showing or hiding toolbar groups based on the window width, and refactors the toolbar menu into a reusable, composable component. It also removes hardcoded CSS media queries in favor of runtime logic using a new `useWindowSize` hook. The changes improve maintainability, scalability, and user experience across different screen sizes.

**Updates:**

* The document toolbar (`documentToolbar/index.tsx`) now uses the new `useWindowSize` hook to determine the window width and conditionally renders toolbar groups (text formatting, alignment, list formatting) directly or inside a new "More Options" menu, providing a better experience on smaller screens.
* Adds a new `ToolbarMenu` component (`ToolbarMenu/index.tsx`, `ToolbarMenu/styles.ts`) that wraps the popover logic and provides `Trigger` and `Content` subcomponents, making it easy to create contextual menus in the toolbar and elsewhere.
* Removes previous CSS-based responsive logic (media queries and display toggling) from `documentToolbar/styles.ts`, shifting all responsive behavior to JavaScript for better maintainability and flexibility.
* Changes `StyledItem` in `toolbar/styles.ts` from a `div` to a `button` for improved accessibility and semantics.

Closes #8